### PR TITLE
Allow the following types to be considered serializable:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>3.2.8.RELEASE</version>
+            <version>4.3.9.RELEASE</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -109,8 +109,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/test/java/com/connect_group/test/genericbean/BeanLocatorTest.java
+++ b/src/test/java/com/connect_group/test/genericbean/BeanLocatorTest.java
@@ -35,7 +35,7 @@ public class BeanLocatorTest {
 
         Set<BeanDefinition> beanDefs = locator.getBeansThatAreNotExcluded("key");
 
-        assertThat(beanDefs, hasSize(4));
+        assertThat(beanDefs, hasSize(8));
     }
 
     @Test

--- a/src/test/java/com/connect_group/test/genericbean/GenericBeanIsSerializableTestsTest.java
+++ b/src/test/java/com/connect_group/test/genericbean/GenericBeanIsSerializableTestsTest.java
@@ -30,4 +30,28 @@ public class GenericBeanIsSerializableTestsTest {
         GenericBeanIsSerializableTests test = new GenericBeanIsSerializableTests("com.connect_group.test.genericbean.testbeans.HasListInBean");
         test.shouldBeSerializable();
     }
+
+    @Test
+    public void shouldPass_WhenMemberIsNestedCollection() throws ClassNotFoundException {
+        GenericBeanIsSerializableTests test = new GenericBeanIsSerializableTests("com.connect_group.test.genericbean.testbeans.HasNestedListInBean");
+        test.shouldBeSerializable();
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldFail_WhenMemberIsNonSerializableNestedCollection() throws ClassNotFoundException {
+        GenericBeanIsSerializableTests test = new GenericBeanIsSerializableTests("com.connect_group.test.genericbean.testbeans.HasNonSerializableNestedListInBean");
+        test.shouldBeSerializable();
+    }
+
+    @Test
+    public void shouldPass_WhenMemberIsMap() throws ClassNotFoundException {
+        GenericBeanIsSerializableTests test = new GenericBeanIsSerializableTests("com.connect_group.test.genericbean.testbeans.HasMapInBean");
+        test.shouldBeSerializable();
+    }
+
+    @Test
+    public void shouldPass_WhenMemberIsLocalDate() throws ClassNotFoundException {
+        GenericBeanIsSerializableTests test = new GenericBeanIsSerializableTests("com.connect_group.test.genericbean.testbeans.HasLocalDateInBean");
+        test.shouldBeSerializable();
+    }
 }

--- a/src/test/java/com/connect_group/test/genericbean/testbeans/HasLocalDateInBean.java
+++ b/src/test/java/com/connect_group/test/genericbean/testbeans/HasLocalDateInBean.java
@@ -1,0 +1,9 @@
+package com.connect_group.test.genericbean.testbeans;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+public class HasLocalDateInBean implements Serializable {
+
+    private LocalDate localDate;
+}

--- a/src/test/java/com/connect_group/test/genericbean/testbeans/HasMapInBean.java
+++ b/src/test/java/com/connect_group/test/genericbean/testbeans/HasMapInBean.java
@@ -1,0 +1,9 @@
+package com.connect_group.test.genericbean.testbeans;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class HasMapInBean implements Serializable {
+
+    private Map<String, String> map;
+}

--- a/src/test/java/com/connect_group/test/genericbean/testbeans/HasNestedListInBean.java
+++ b/src/test/java/com/connect_group/test/genericbean/testbeans/HasNestedListInBean.java
@@ -1,0 +1,9 @@
+package com.connect_group.test.genericbean.testbeans;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class HasNestedListInBean implements Serializable {
+
+    private List<List<String>> nestedList;
+}

--- a/src/test/java/com/connect_group/test/genericbean/testbeans/HasNonSerializableNestedListInBean.java
+++ b/src/test/java/com/connect_group/test/genericbean/testbeans/HasNonSerializableNestedListInBean.java
@@ -1,0 +1,9 @@
+package com.connect_group.test.genericbean.testbeans;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class HasNonSerializableNestedListInBean implements Serializable {
+
+    private List<List<SimpleBean>> nonSerializableNestedList;
+}


### PR DESCRIPTION
* Maps
* Nested Collections (and Maps) - e.g. List<List<String>>
* Any Java SDK class that declares itself Serializable (some - e.g. LocalDate - implement readObject but not writeObject)

Note that this also bumps for required Java version to 1.8